### PR TITLE
Fix mixed-content errors and update links https

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <title>Royal Navy of WW1</title>
-    <link rel="shortcut icon" href="http://cartodb.com/favicon/favicon_32x32.ico" />
     <link type="text/css" rel="stylesheet" media="all" href="css/style.css?v=1"></link>
     <link type="text/css" rel="stylesheet" media="all" href="font/font-awesome.css"></link>
   </head>
@@ -12,7 +11,7 @@
 
     <div class="header">
       <div class="inner">
-      <div class="title" style="width:250px;"><h1>a <a href="http://www.cartodb.com">CartoDB</a> &amp; <a href="http://zooniverse.org">Zooniverse</a> collaboration</h1></div>
+      <div class="title" style="width:250px;"><h1>a <a href="https://carto.com">Carto</a> &amp; <a href="http://zooniverse.org">Zooniverse</a> collaboration</h1></div>
       <div class="link"><a href="http://strataconf.com/strataeu">made with care for Strataconf:London</a></div>
       <div class="ribbon">
           <h2 style="font-size:16px;">The Navy of WWI</h2>
@@ -39,7 +38,7 @@
     <div class="subsContent">
       <div class="torque_subs" ></div>
     </div>
-      <a class="cartodb_logo" href="http://www.cartodb.com" target="_blank">CartoDB</a>
+      <a class="cartodb_logo" href="https://carto.com" target="_blank">Carto</a>
       <div id="oldWeatherMap" class="map"></div>
     </div>
 
@@ -54,7 +53,7 @@
       <h3>ABOUT THIS VISUALIZATION</h3>
       <div class="text">
         This visualization maps 1 million WWI <a href="http://www.naval-history.net/OWShips-LogBooksWW1.htm">Royal Navy</a> locations transcribed by the citizen scientists of <a href="http://blog.oldweather.org/2012/07/23/one-million-six-hundred-thousand-new-observations/">Old Weather</a>.
-        <div class="learnmore">Read more at <a href="http://blog.cartodb.com" target="_blank">blog.cartodb.com</a></div>
+        <div class="learnmore">Read more at <a href="https://carto.com/blog/" target="_blank">carto.com/blog/</a></div>
       </div>
     </div>
     <div class="bigRibbon center">
@@ -84,11 +83,11 @@
     </div>
 
     <div class="footer">
-      a <a href="http://cartodb.com">CartoDB</a> &amp; <a href="http://zooniverse.org">Zooniverse</a> collaboration inspired by <a href="http://brohan.org/~philip/index.html">Philip Brohan</a>. Built with <a href="https://dl.dropbox.com/u/193220/cartodb_datacubes.pdf" style="text-decoration:underline;">CartoDB Datacubes</a>. <a href="https://github.com/CartoDB/oldweather_wwi">GitHub</a>.
+      a <a href="https://carto.com">Carto</a> &amp; <a href="http://zooniverse.org">Zooniverse</a> collaboration inspired by <a href="http://brohan.org/~philip/index.html">Philip Brohan</a>. Built with <a href="https://dl.dropbox.com/u/193220/cartodb_datacubes.pdf" style="text-decoration:underline;">CartoDB Datacubes</a>. <a href="https://github.com/CartoDB/oldweather_wwi">GitHub</a>.
     </div>
 
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-    <script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
     <script type="text/javascript" src="lib/jquery.easing.1.3.js"></script>
     <script type="text/javascript" src="lib/oldWeather.lib.min.js"></script>
     <script type="text/javascript" src="src/app.vendors.min.js"></script>


### PR DESCRIPTION
Update links to `https` to fix mixed-content errors and update few links to the new `carto` website  
